### PR TITLE
Add lock to @cached TTLCache to fix race under concurrent requests

### DIFF
--- a/vectorizer.py
+++ b/vectorizer.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
 from pydantic import BaseModel
 from typing import Optional
 from cachetools import cached, TTLCache
@@ -42,7 +43,7 @@ class Model2VecVectorizer:
     def __init__(self, model_path: str):
         self.model = StaticModel.load_local(model_path)
 
-    @cached(cache=TTLCache(maxsize=1024, ttl=600))
+    @cached(cache=TTLCache(maxsize=1024, ttl=600), lock=Lock())
     def vectorize(self, text: str, config: VectorInputConfig):
         embeddings = self.model.encode([text], use_multiprocessing=True)
         return embeddings[0]


### PR DESCRIPTION
## Summary

- Pass a `threading.Lock()` to the `@cached` decorator on `Model2VecVectorizer.vectorize` so the shared `TTLCache` is accessed safely from the `ThreadPoolExecutor` workers.

## Motivation

`cachetools` is explicitly not thread-safe. The vectorize method is invoked concurrently via `Vectorizer.executor.submit(...)`, so two threads can collide on `__setitem__` → `popitem()` (LRU eviction / TTL expiry) and produce `RuntimeError: OrderedDict mutated during iteration` (or a stringified `KeyError` tuple surfaced as the error message). Adding `lock=Lock()` is the documented synchronization mechanism.

Fixes #15

## Test plan

- [ ] Restart the model2vec pod with this image and re-run the Weaviate batch ingest that previously triggered the race (100k objects, batch size 1000) — confirm no 500s of the two forms documented in #15.
- [ ] Confirm `/vectors` latency is unchanged at low concurrency (lock contention should be negligible since the critical section is just cache get/set).