### PR TITLE
Disable multiprocessing for single-text encode

### DIFF
--- a/vectorizer.py
+++ b/vectorizer.py
@@ -44,7 +44,7 @@ class Model2VecVectorizer:
 
     @cached(cache=TTLCache(maxsize=1024, ttl=600))
     def vectorize(self, text: str, config: VectorInputConfig):
-        embeddings = self.model.encode([text], use_multiprocessing=True)
+        embeddings = self.model.encode([text], use_multiprocessing=False)
         return embeddings[0]
 
 


### PR DESCRIPTION
## Summary

- Switch `self.model.encode([text], use_multiprocessing=True)` to `use_multiprocessing=False` in `Model2VecVectorizer.vectorize`.

## Motivation

The vectorize call runs per `/vectors` request on a single-element list (`[text]`) from inside a `ThreadPoolExecutor` worker. `use_multiprocessing=True` dispatches the encode to a process pool, paying fork/IPC/serialization overhead for one short input — there is nothing to parallelize across processes.

Request-level concurrency is already provided by the executor in `Vectorizer.__init__`, so the multiprocessing layer is redundant and slower. Disabling it should reduce per-request latency and CPU/memory footprint under load, and eliminate a class of multiprocessing failure modes (fork issues in containers, pickling errors, semaphore leaks).

Fixes #16

## Test plan

- [ ] Local latency check at concurrency 1, 10, 50 — confirm p50/p95 latency is lower (or at least no worse) than `main`.
- [ ] Smoke test the existing test suite (`smoke_test.py`, `smoke_auth_test.py`, `smoke_validate_cache_test.py`) against the rebuilt image.
- [ ] Sanity-check that emitted vectors are bit-identical to `main` for the same input.