### PR TITLE
fix: disable FastAPI strict Content-Type checking and add client compatibility tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan, strict_content_type=False)
 
 
 @app.get("/.well-known/live", response_class=Response)

--- a/cicd/test.sh
+++ b/cicd/test.sh
@@ -9,19 +9,28 @@ pip3 install -r requirements-test.txt
 echo "Running tests with authorization on"
 
 container_id=$(docker run -d -it -e AUTHENTICATION_ALLOWED_TOKENS='token1,token2' -p "8000:8080" "$local_repo")
+trap "docker stop $container_id" EXIT
 
 python3 smoke_auth_test.py
 
 docker stop $container_id
+trap - EXIT
 
 echo "Running tests without authorization"
 
 container_id=$(docker run -d -it -p "8000:8080" "$local_repo")
+trap "docker stop $container_id" EXIT
 
 echo "Running smoke tests"
 python3 smoke_test.py
 
-echo "Running validating cache smoke tests"
+echo "Running cache validation smoke tests"
 python3 smoke_validate_cache_test.py
+
+echo "Running client compatibility tests"
+python3 smoke_compatibility_test.py
+
+docker stop $container_id
+trap - EXIT
 
 echo "Success"

--- a/cicd/test.sh
+++ b/cicd/test.sh
@@ -9,7 +9,7 @@ pip3 install -r requirements-test.txt
 echo "Running tests with authorization on"
 
 container_id=$(docker run -d -it -e AUTHENTICATION_ALLOWED_TOKENS='token1,token2' -p "8000:8080" "$local_repo")
-trap "docker stop $container_id" EXIT
+trap 'docker stop "$container_id" || true' EXIT
 
 python3 smoke_auth_test.py
 
@@ -19,7 +19,7 @@ trap - EXIT
 echo "Running tests without authorization"
 
 container_id=$(docker run -d -it -p "8000:8080" "$local_repo")
-trap "docker stop $container_id" EXIT
+trap 'docker stop "$container_id" || true' EXIT
 
 echo "Running smoke tests"
 python3 smoke_test.py

--- a/smoke_compatibility_test.py
+++ b/smoke_compatibility_test.py
@@ -1,0 +1,133 @@
+import json
+import time
+import threading
+import unittest
+import urllib.request
+
+import requests
+
+
+class CompatibilityTest(unittest.TestCase):
+    """Regression tests that guard against client-compatibility breakages.
+
+    Each test is named after the production incident it would have caught:
+      - test_request_without_content_type_header  → FastAPI 0.132 strict_content_type (HTTP 422)
+      - test_request_with_extra_body_fields        → Weaviate Go client extra JSON fields
+      - test_concurrent_requests_no_500            → TTLCache race condition (OrderedDict mutation)
+      - test_task_type_configs                     → passage / query task_type round-trip
+      - test_cached_vector_is_deterministic        → cache correctness after concurrent writes
+    """
+
+    def setUp(self):
+        self.url = "http://localhost:8000"
+        for i in range(100):
+            try:
+                res = requests.get(self.url + "/.well-known/ready")
+                if res.status_code == 204:
+                    return
+            except Exception as e:
+                print(f"Attempt {i}: {e}")
+                time.sleep(1)
+        raise Exception("service did not start up in time")
+
+    def test_request_without_content_type_header(self):
+        """JSON body with no Content-Type header must return 200, not 422.
+
+        FastAPI >= 0.132 introduced strict Content-Type checking by default.
+        We disable it (strict_content_type=False) so that clients such as
+        Weaviate's shared transformer Go client — which never set the header —
+        keep working after a FastAPI version bump.
+        """
+        body = json.dumps({"text": "The London Eye is a ferris wheel."}).encode()
+        req = urllib.request.Request(
+            self.url + "/vectors",
+            data=body,
+            method="POST",
+        )
+        # Deliberately no Content-Type header — mirrors the Go http.NewRequestWithContext
+        # call that was missing req.Header.Set("Content-Type", "application/json").
+        with urllib.request.urlopen(req) as resp:
+            self.assertEqual(200, resp.status)
+            payload = json.loads(resp.read())
+        self.assertGreater(len(payload["vector"]), 0)
+
+    def test_request_with_extra_body_fields(self):
+        """Extra JSON fields sent by the Weaviate transformer client must be ignored.
+
+        Weaviate's vecRequest struct serialises dims, vector, and error alongside
+        text and config. Pydantic must silently discard unknown fields rather than
+        returning 422.
+        """
+        body = {
+            "text": "The London Eye is a ferris wheel.",
+            "dims": 0,
+            "vector": None,
+            "error": "",
+            "config": {"task_type": "passage"},
+        }
+        res = requests.post(self.url + "/vectors", json=body)
+        self.assertEqual(200, res.status_code, res.text)
+        self.assertGreater(len(res.json()["vector"]), 0)
+
+    def test_concurrent_requests_no_500(self):
+        """50 concurrent vectorize calls must all succeed.
+
+        Regression for the TTLCache race condition that produced
+        'RuntimeError: OrderedDict mutated during iteration' (HTTP 500) when
+        the @cached decorator was used without a threading lock.
+        """
+        texts = [f"Concurrent sentence {i} on a distinct topic." for i in range(50)]
+        errors = []
+
+        def vectorize(text):
+            try:
+                res = requests.post(self.url + "/vectors", json={"text": text})
+                if res.status_code != 200:
+                    errors.append(f"[{res.status_code}] {res.text}")
+            except Exception as exc:
+                errors.append(str(exc))
+
+        threads = [threading.Thread(target=vectorize, args=(t,)) for t in texts]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        self.assertEqual([], errors, f"Concurrent requests failed:\n" + "\n".join(errors))
+
+    def test_task_type_configs(self):
+        """Both passage and query task_type values produce a valid vector."""
+        text = "The London Eye is a ferris wheel at the River Thames."
+        for task_type in ("passage", "query"):
+            res = requests.post(
+                self.url + "/vectors",
+                json={"text": text, "config": {"task_type": task_type}},
+            )
+            self.assertEqual(200, res.status_code, f"task_type={task_type}: {res.text}")
+            self.assertGreater(len(res.json()["vector"]), 0)
+
+    def test_cached_vector_is_deterministic(self):
+        """Repeated calls for identical text return bit-identical vectors.
+
+        Validates that the TTLCache returns a stable result after concurrent
+        writes and that the lock does not corrupt cached values.
+        """
+        text = "Determinism check: this sentence must always yield the same vector."
+        results = []
+
+        def fetch():
+            res = requests.post(self.url + "/vectors", json={"text": text})
+            self.assertEqual(200, res.status_code, res.text)
+            results.append(res.json()["vector"])
+
+        threads = [threading.Thread(target=fetch) for _ in range(10)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        self.assertTrue(all(v == results[0] for v in results), "Vectors diverged across calls")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/smoke_compatibility_test.py
+++ b/smoke_compatibility_test.py
@@ -17,11 +17,12 @@ class CompatibilityTest(unittest.TestCase):
       - test_cached_vector_is_deterministic        → cache correctness after concurrent writes
     """
 
-    def setUp(self):
-        self.url = "http://localhost:8000"
+    @classmethod
+    def setUpClass(cls):
+        cls.url = "http://localhost:8000"
         for i in range(100):
             try:
-                res = requests.get(self.url + "/.well-known/ready")
+                res = requests.get(cls.url + "/.well-known/ready")
                 if res.status_code == 204:
                     return
             except Exception as e:
@@ -103,7 +104,7 @@ class CompatibilityTest(unittest.TestCase):
         for th in threads:
             th.join()
 
-        self.assertEqual([], errors, f"Concurrent requests failed:\n" + "\n".join(errors))
+        self.assertEqual([], errors, "Concurrent requests failed:\n" + "\n".join(errors))
 
     def test_task_type_configs(self):
         """Both passage and query task_type values produce a valid vector."""

--- a/smoke_compatibility_test.py
+++ b/smoke_compatibility_test.py
@@ -2,7 +2,6 @@ import json
 import time
 import threading
 import unittest
-import urllib.request
 
 import requests
 
@@ -37,19 +36,15 @@ class CompatibilityTest(unittest.TestCase):
         We disable it (strict_content_type=False) so that clients such as
         Weaviate's shared transformer Go client — which never set the header —
         keep working after a FastAPI version bump.
+
+        requests.post(data=bytes) sends the raw body without adding a
+        Content-Type header, mirroring Go's http.NewRequestWithContext with
+        no header set. Using json= instead would silently add the header.
         """
         body = json.dumps({"text": "The London Eye is a ferris wheel."}).encode()
-        req = urllib.request.Request(
-            self.url + "/vectors",
-            data=body,
-            method="POST",
-        )
-        # Deliberately no Content-Type header — mirrors the Go http.NewRequestWithContext
-        # call that was missing req.Header.Set("Content-Type", "application/json").
-        with urllib.request.urlopen(req) as resp:
-            self.assertEqual(200, resp.status)
-            payload = json.loads(resp.read())
-        self.assertGreater(len(payload["vector"]), 0)
+        res = requests.post(self.url + "/vectors", data=body)
+        self.assertEqual(200, res.status_code, f"Expected 200, got {res.status_code}: {res.text}")
+        self.assertGreater(len(res.json()["vector"]), 0)
 
     def test_request_with_content_type_header(self):
         """JSON body with Content-Type: application/json must return 200.
@@ -58,16 +53,13 @@ class CompatibilityTest(unittest.TestCase):
         standard well-behaved clients are unaffected by strict_content_type=False.
         """
         body = json.dumps({"text": "The London Eye is a ferris wheel."}).encode()
-        req = urllib.request.Request(
+        res = requests.post(
             self.url + "/vectors",
             data=body,
-            method="POST",
             headers={"Content-Type": "application/json"},
         )
-        with urllib.request.urlopen(req) as resp:
-            self.assertEqual(200, resp.status)
-            payload = json.loads(resp.read())
-        self.assertGreater(len(payload["vector"]), 0)
+        self.assertEqual(200, res.status_code, f"Expected 200, got {res.status_code}: {res.text}")
+        self.assertGreater(len(res.json()["vector"]), 0)
 
     def test_request_with_extra_body_fields(self):
         """Extra JSON fields sent by the Weaviate transformer client must be ignored.

--- a/smoke_compatibility_test.py
+++ b/smoke_compatibility_test.py
@@ -51,6 +51,24 @@ class CompatibilityTest(unittest.TestCase):
             payload = json.loads(resp.read())
         self.assertGreater(len(payload["vector"]), 0)
 
+    def test_request_with_content_type_header(self):
+        """JSON body with Content-Type: application/json must return 200.
+
+        Counterpart to test_request_without_content_type_header — ensures
+        standard well-behaved clients are unaffected by strict_content_type=False.
+        """
+        body = json.dumps({"text": "The London Eye is a ferris wheel."}).encode()
+        req = urllib.request.Request(
+            self.url + "/vectors",
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:
+            self.assertEqual(200, resp.status)
+            payload = json.loads(resp.read())
+        self.assertGreater(len(payload["vector"]), 0)
+
     def test_request_with_extra_body_fields(self):
         """Extra JSON fields sent by the Weaviate transformer client must be ignored.
 


### PR DESCRIPTION
## Motivation

The Weaviate Go transformer client (`text2vec-transformers`) sends POST requests without a `Content-Type: application/json` header — it uses `http.NewRequestWithContext` but never sets the header. FastAPI 0.132 introduced `strict_content_type=True` as its new default, which causes these bare-body requests to return HTTP 422 instead of 200, silently breaking vectorization for any deployment that bumps the FastAPI version.

## Approach

Set `strict_content_type=False` on the FastAPI app instance. This is a one-line config change — FastAPI already supports the flag, no middleware or request parsing changes are needed.

The companion test suite (`smoke_compatibility_test.py`) is structured as named regression tests, each tied to a concrete past or potential failure mode. The intent is that future breakages are caught before they reach production, not diagnosed from support tickets.

## Key areas for review

- `app.py:48` — the single-line fix; verify this is the correct FastAPI parameter and that it doesn't weaken any security boundary (it controls media-type enforcement, not auth)
- `smoke_compatibility_test.py` — the full compatibility test suite; worth reading the docstrings to confirm each test would have caught its named incident
- `cicd/test.sh` — `trap` cleanup was added around all three container lifecycles; check that the pattern is correct for early exits

## Risks and mitigations

- **Accepting non-JSON bodies**: `strict_content_type=False` means FastAPI will attempt to parse any body as JSON regardless of the declared content type. Pydantic will still reject malformed JSON with a 422, so the practical risk is limited to clients sending valid JSON with a wrong/missing header — which is exactly the case we want to support.
- **Trap cleanup in test.sh**: adding `trap "docker stop $container_id" EXIT` ensures containers are stopped even if a test suite exits non-zero. The `trap - EXIT` reset after each explicit `docker stop` prevents double-stop on clean paths.

## Testing

`smoke_compatibility_test.py` covers five scenarios:
1. JSON body with no `Content-Type` header — the regression case (would have caught the FastAPI 0.132 breakage)
2. JSON body with `Content-Type: application/json` — counterpart ensuring well-behaved clients are unaffected
3. Extra fields in the request body — mirrors the Go client's `vecRequest` struct with `dims`, `vector`, `error` alongside `text`
4. 50 concurrent requests — regression for the `TTLCache` `OrderedDict` race condition that produced HTTP 500s
5. Repeated calls for identical text returning bit-identical vectors — validates cache correctness under concurrency

Closes #15 (related), closes #16 (related)